### PR TITLE
39: Fix CAPTCHA getting caught up in page cache.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ vendor/
 gravityforms-text-captcha-*.tar.gz
 .phplint-cache
 .phpunit.result.cache
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 VERSION := $(shell git symbolic-ref -q --short HEAD)
 BUILD_ARTIFACT := gravityforms-text-captcha-${VERSION}.tar.gz
-
-.PHONY: default
-default: test
+.DEFAULT_GOAL := test
 
 .PHONY: lint
 lint: init

--- a/src/gravityforms-text-captcha.php
+++ b/src/gravityforms-text-captcha.php
@@ -55,7 +55,7 @@ if (class_exists('GF_Fields')) {
     });
   } else {
     // Normal page.
-    // Register REST API endpoint for "Try Another" button.
+    // Register REST API endpoints.
     add_action('rest_api_init', function () {
       $cfg = new GF_TextCaptcha_Config();
       $cfg->initialize();

--- a/src/include/GF_Field_TextCaptcha.inc
+++ b/src/include/GF_Field_TextCaptcha.inc
@@ -36,19 +36,19 @@ EOF;
   // @return {string} JavaScript to emit.
   public function get_form_inline_script_on_page_render($form) {
     $form_id = (int) rgar($form, 'id');
+    $field_id = $this->id;
     return <<<EOF
 window.GF_TextCaptcha = {
-  reloadCaptcha: function(fieldId) {
+  reloadCaptcha: function() {
     // Find field element.
-    fieldIdStr = fieldId.toString();
-    elemSelector = '#field_${form_id}_' + fieldIdStr;
+    elemSelector = '#field_${form_id}_${field_id}';
     jQuery(elemSelector).each(function (i, elem) {
       jQuery(elem).find('INPUT.try_another')
         .prop('disabled', true);
 
       // Call API for new CAPTCHA.
       jQuery.ajax({
-        url: '/wp-json/gravityforms-text-captcha/v1/form/${form_id}/captcha/' + fieldIdStr,
+        url: '/wp-json/gravityforms-text-captcha/v1/form/${form_id}/captcha/${field_id}/',
         type: 'GET',
         dataType: 'json',
         success: function (data) {
@@ -76,6 +76,8 @@ window.GF_TextCaptcha = {
     });
   }
 };
+
+window.GF_TextCaptcha.reloadCaptcha();
 EOF;
   }
 
@@ -117,11 +119,8 @@ EOF;
   // @param {array|null} $entry Entry object currently being edited.
   // @return {string} HTML output.
   public function get_field_input($form, $value = '', $entry = null) {
-    // $form_id = (int) $this->id;
-    error_log('get_field_input() ' . serialize($this));
-    $field_id = 2;
     $is_editmode = $this->is_form_editor();
-    return GF_Field_TextCaptcha::$generator->generate_html($field_id, $is_editmode);
+    return GF_Field_TextCaptcha::$generator->generate_html($this->id, $is_editmode, false);
   }
 
   // Validate form input.

--- a/src/include/GF_TextCaptcha_API.inc
+++ b/src/include/GF_TextCaptcha_API.inc
@@ -12,7 +12,7 @@ class GF_TextCaptcha_API {
   public function register_routes() {
     register_rest_route('gravityforms-text-captcha/v1', '/form/(?P<form_id>\d+)/captcha/(?P<field_id>\d+)', [
       'methods' => 'GET',
-      'callback' => [$this, 'get_captcha'],
+      'callback' => [$this, '_get_captcha'],
       'args' => [
         'form_id' => [
           'validate_callback' => function ($param, $request, $key) {
@@ -31,11 +31,13 @@ class GF_TextCaptcha_API {
   // Generate new CAPTCHA HTML for Text CAPTCHA field contents.
   // @param {WP_REST_Request} $request
   // @return {any} JSON serializable response content.
-  public function get_captcha(WP_REST_Request $request) {
+  public function _get_captcha(WP_REST_Request $request) {
     $field_id = (int) $request->get_param('field_id');
     $is_editmode = $request->get_param('editmode') != 'false';
-    return [
-      'html' => $this->generator->generate_html($field_id, $is_editmode)
-    ];
+    $response = new WP_REST_Response([
+      'html' => $this->generator->generate_html($field_id, $is_editmode, true)
+    ]);
+    $response->header('Cache-Control', 'no-cache');
+    return $response;
   }
 }

--- a/src/include/GF_TextCaptcha_Generator.inc
+++ b/src/include/GF_TextCaptcha_Generator.inc
@@ -12,15 +12,20 @@ class GF_TextCaptcha_Generator {
   // Generate text CAPTCHA field HTML.
   // $field_id: Field id.
   // $is_editmode: True if rendering in form editor.
+  // $render_captcha: True if rendering a CAPTCHA; false if just a blank template.
   // Returns HTML.
-  public function generate_html($field_id, $is_editmode) {
+  public function generate_html($field_id, $is_editmode, $render_captcha) {
     $captcha_str = $this->generate_captcha_str();
     $code = $this->generate_captcha_code($captcha_str);
 
-    $noise_html = $this->html_noise();
-
-    $captcha_text = htmlentities($this->make_figlet_image($captcha_str));
-    $captcha_html = $this->html_format_captcha_text($captcha_text);
+    if ($render_captcha || $is_editmode) {
+      $noise_html = $this->html_noise();
+      $captcha_text = htmlentities($this->make_figlet_image($captcha_str));
+      $captcha_html = $this->html_format_captcha_text($captcha_text);
+    } else {
+      $noise_html = "";
+      $captcha_html = "";
+    }
 
     $input_attrs = "";
     if ($is_editmode) {
@@ -35,7 +40,7 @@ EOF;
 
     $try_another_html = <<<EOF
 <div class="gfield_text_captcha_try_another">
-  <input type="button" class="gform_button button try_another" value="Try Another" onclick="window.GF_TextCaptcha.reloadCaptcha(${field_id})" />
+  <input type="button" class="gform_button button try_another" value="Try Another"$input_attrs onclick="window.GF_TextCaptcha.reloadCaptcha()" />
 </div>
 EOF;
 


### PR DESCRIPTION
Render always calls REST API to render on first load.
REST API response set to disable cache.

Closes #39 